### PR TITLE
Use scroll instead of touchstart

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function (element) {
-  function onTouchstart() {
+  function onScroll() {
     var scrollTop = element.scrollTop;
 
     // If the view is scrolled all the way to the top or bottom, scroll down
@@ -13,9 +13,11 @@ module.exports = function (element) {
     }
   }
 
-  element.addEventListener('touchstart', onTouchstart);
+  onScroll(); // Init.
+
+  element.addEventListener('scroll', onScroll);
 
   return function () {
-    element.removeEventListener('touchstart', onTouchstart);
+    element.removeEventListener('scroll', onScroll);
   };
 };

--- a/tests.js
+++ b/tests.js
@@ -13,16 +13,21 @@ var element = {
 };
 
 test('Prevent Overscroll', function (assert) {
-  assert.plan(5);
+  assert.plan(6);
 
   var remove = preventOverscroll(element);
   var listener = element.addEventListener.getCall(0).args[1];
 
   assert.ok(
-    element.addEventListener.calledWithExactly('touchstart', listener),
-    'adds touchstart event listener'
+    element.addEventListener.calledWithExactly('scroll', listener),
+    'adds scroll event listener'
   );
 
+  assert.equals(
+    element.scrollTop, 1, 'scrolls down 1px on init'
+  );
+
+  element.scrollTop = 0;
   listener();
 
   assert.equals(element.scrollTop, 1, 'scrolls down 1px');
@@ -39,7 +44,7 @@ test('Prevent Overscroll', function (assert) {
   remove();
 
   assert.ok(
-    element.removeEventListener.calledWithExactly('touchstart', listener),
-    'removes touchstart event listener'
+    element.removeEventListener.calledWithExactly('scroll', listener),
+    'removes scroll event listener'
   );
 });


### PR DESCRIPTION
I've been investigating a fix for the iOS body scroll bug for a little while and found your solution solves the problem nicely for me, but only ~50% of the time, it usually fails when swiping fast.

I think it might be because the DOM, being a retained mode API, won't have necessarily applied the new `scrollTop` before the browser handles the scroll.

I noticed Google's AMP pages solve the problem pretty consistently so after [discussing it with some of their devs on twitter](https://twitter.com/riscarrott/status/880506408227287042) I found they basically do [the exact same thing as you do here but on 'scroll' instead of 'touchstart'](https://github.com/ampproject/amphtml/blob/9997635a316cc69530d35320c80201f0f5f0594f/src/service/viewport-impl.js#L1846) (albeit they don't handle overscroll at the bottom of the page, citing `scrollHeight` as too expensive).

This means the scroll position is reset to `1` or `scrollHeight - 1` after the last interaction rather than just before the next interaction and anecdotally it works more consistently for me, maybe 99% of the time -- the only way to inadvertently trigger the body scroll is by catching the scroll at 0 before the scroll event has fired -- but I've found this to be very rare.

Additionally @dvoytenko made the point that 'scroll' would be better than 'touch*' events because it's passive by default (i.e. e.preventDefault() doesn't prevent scrolling) so the browser can start scrolling without waiting for the handler to complete.

